### PR TITLE
correct typo in axis name: IFNM -> INFM

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -161,7 +161,7 @@
 		</p></div>
 
 	<div id="INFM" class="axis svelte-13ur8oz"><div class="axis-diagram svelte-13ur8oz"><span class="min svelte-13ur8oz">HHH</span><span class="between gray svelte-13ur8oz">→</span><span class="max svelte-13ur8oz">HHH</span></div>
-		<h3 class="axis-name svelte-13ur8oz">Informality <span class="axis-range svelte-13ur8oz">(0 to 100)</span> <span class="axis-tag svelte-13ur8oz">IFNM</span></h3>
+		<h3 class="axis-name svelte-13ur8oz">Informality <span class="axis-range svelte-13ur8oz">(0 to 100)</span> <span class="axis-tag svelte-13ur8oz">INFM</span></h3>
 		<p class="svelte-13ur8oz">Adjusts glyph shapes from normalized proportions (with consistent heights and proportions for
 			everyday typography) to irregular shaping and sizing (more like handwriting).
 		</p></div>

--- a/src/lib/Definitions.svelte
+++ b/src/lib/Definitions.svelte
@@ -41,7 +41,7 @@
 			<span class="min">HHH</span><span class="between gray">→</span><span class="max">HHH</span>
 		</div>
 		<h3 class="axis-name">
-			Informality <span class="axis-range">(0 to 100)</span> <span class="axis-tag">IFNM</span>
+			Informality <span class="axis-range">(0 to 100)</span> <span class="axis-tag">INFM</span>
 		</h3>
 		<p>
 			Adjusts glyph shapes from normalized proportions (with consistent heights and proportions for


### PR DESCRIPTION
I noticed the name of the Informality axis was spelled wrong on the specimen site.

I wasn't sure what to do about `docs/_app/immutable/components/pages/_page.svelte-d393fad2.js`.  It looked generated, but I'm not sure how, so I left it alone.